### PR TITLE
重力反転ボタンのちょっとした修正

### DIFF
--- a/src/objects/character.js
+++ b/src/objects/character.js
@@ -72,12 +72,22 @@ class CharaClass {
         // 描画
         rect(this.x, this.y, this.width, this.height);
         if (this.dx > 0 || this.dx == 0 && this.facebuf == 0) {
-            line(this.x + 24, this.y + 10, this.x + 24, this.y + 30);
-            line(this.x + 36, this.y + 10, this.x + 36, this.y + 30);
+            if (gravity == 'down') {
+                line(this.x + 24, this.y + 10, this.x + 24, this.y + 30);
+                line(this.x + 36, this.y + 10, this.x + 36, this.y + 30);
+            } else if (gravity == 'up') {
+                line(this.x + 24, this.y + 20, this.x + 24, this.y + 40);
+                line(this.x + 36, this.y + 20, this.x + 36, this.y + 40);
+            }
             this.facebuf = 0;
         } else if (this.dx < 0 || this.dx == 0 && this.facebuf == 1) {
-            line(this.x + 13, this.y + 10, this.x + 13, this.y + 30);
-            line(this.x + 25, this.y + 10, this.x + 25, this.y + 30);
+            if (gravity == 'down') {
+                line(this.x + 13, this.y + 10, this.x + 13, this.y + 30);
+                line(this.x + 25, this.y + 10, this.x + 25, this.y + 30);
+            } else if (gravity == 'up') {
+                line(this.x + 13, this.y + 20, this.x + 13, this.y + 40);
+                line(this.x + 25, this.y + 20, this.x + 25, this.y + 40);
+            }
             this.facebuf = 1;
         }
     }

--- a/src/objects/gravitybutton.js
+++ b/src/objects/gravitybutton.js
@@ -29,7 +29,8 @@ class GravityButton extends ObjectClass {
         // 衝突した際の処理
         //this.changed = (touch == 4) ? true : false;
         if (touch == 4 && !(this.changed)) {
-            gravity = (gravity == "down") ? "up" : "down";  // 重力の向きを反転
+            gravity = (gravity == "down") ? "up" : "down";  // 重力の向き(ジャンプの向き)を反転
+            chr.setDDY(-chr.getDDY());  // 自機の重力加速度を反転
             this.gravChanged = true;
         } else if (touch != 4) {
             this.gravChanged = false;

--- a/src/stage/world0.js
+++ b/src/stage/world0.js
@@ -46,14 +46,6 @@ function world0() {
                 obj[8].checkClash(chr);  // GravityButtonの重力反転が動作するか判別
                 clash(chr, obj);  // 衝突判定処理
 
-                // 重力反転が発生した場合の処理
-                if(obj[7].gravChanged == true) {
-                    chr.setDDY(-chr.getDDY());   // 自機の重力加速度を反転
-                }
-                if(obj[8].gravChanged == true) {
-                    chr.setDDY(-chr.getDDY());
-                }
-
                 chr.move();  // 自機の左右移動
                 chr.push();  // 自機の描画
                 pushes(obj);  // obj配列の要素の描画


### PR DESCRIPTION
重力が反転したときにキャラクターの顔も反転するようにした。
また、キャラクターの重力加速度を反転させる処理をクラス内に書き加えたので、ワールドファイルに直接重力加速度を反転させる処理を書く必要がなくなった。