### PR TITLE
重力反転ボタンをまた修正した

### DIFF
--- a/src/objects/gravitybutton.js
+++ b/src/objects/gravitybutton.js
@@ -1,9 +1,18 @@
 /* 重力反転ボタン用長方形クラス */
 class GravityButton extends ObjectClass {
     // コンストラクタ
-    constructor() {
+    constructor(position) {
         super(1, 0.25, true);
+        this.position = position;  // 重力反転ボタンが床と天井のどちらに設置されているかを判別する変数
         this.gravChanged = false;  // 重力反転が完了すると立つフラグ
+    }
+
+    // 床に設置する場合はy座標に37.5を加算する
+    init(x_block, y_block, red, green, blue) {
+        super.init(x_block, y_block, red, green, blue);
+        if (this.position == "floor") {
+            this.y += 37.5;
+        }
     }
 
     // 描画メソッド
@@ -15,6 +24,14 @@ class GravityButton extends ObjectClass {
             stroke(255);
         }
         rect(this.x, this.y, this.width, this.height);
+
+        line(this.x + this.width / 3, this.y, this.x + this.width / 3, this.y + this.height);
+        line(this.x + this.width / 3, this.y + this.height, this.x + this.width / 3 - 6, this.y + this.height - 5);
+        line(this.x + this.width / 3, this.y + this.height, this.x + this.width / 3 + 6, this.y + this.height - 5);
+
+        line(this.x + this.width * 2 / 3, this.y, this.x + this.width * 2 / 3, this.y + this.height);
+        line(this.x + this.width * 2 / 3, this.y, this.x + this.width * 2 / 3 - 6, this.y + 5);
+        line(this.x + this.width * 2 / 3, this.y, this.x + this.width * 2 / 3 + 6, this.y + 5);
     }
 
     // 重力反転が発生するかどうかを判定するメソッド

--- a/src/stage/world0.js
+++ b/src/stage/world0.js
@@ -16,8 +16,8 @@ function world0() {
                     new TransRectClass(1, 5),
                     new ColorChanger(1, 3),
                     new ClearLine(1, 3),
-                    new GravityButton(),
-                    new GravityButton(),
+                    new GravityButton("floor"),
+                    new GravityButton("ceiling"),
                     new OneWayWall(1, 3, "right"),
                 ];
 
@@ -31,7 +31,7 @@ function world0() {
                 obj[4].init(25, 13, 255, 255, 255);
                 obj[5].init(19, 13, 255, 255, 255);
                 obj[6].init(37, 15, 255, 255, 255);
-                obj[7].init(5, 17.75, 255, 255, 255);
+                obj[7].init(5, 17, 255, 255, 255);
                 obj[8].init(7, 3, 255, 255, 255);
                 obj[9].init(32, 15, 255, 255, 255);
 


### PR DESCRIPTION
重力反転ボタンにデザインを付けた。
重力反転ボタンのインスタンス作成時の引数に"floor"もしくは"ceiling"を入れることによって、床に設置するか天井に設置するかを選べるようになった。これによって、床設置時にY座標に+0.75しなくてもよくなった。