### PR TITLE
RGB表色系の実装

### DIFF
--- a/src/objects/character.js
+++ b/src/objects/character.js
@@ -197,6 +197,9 @@ class CharaClass {
     getJumpenable() { return this.jumpenable; }
     setJumpenable(jumpenable) { this.jumpenable = jumpenable; }
 
+    getRed() { return this.red; }
+    getGreen() { return this.green; }
+    getBlue() { return this.blue; }
     setRGB(red, green, blue) {
         this.red = red;
         this.green = green;

--- a/src/objects/colorchanger.js
+++ b/src/objects/colorchanger.js
@@ -1,16 +1,22 @@
 /* 色変更長方形クラス */
 class ColorChanger extends ObjectClass {
     // コンストラクタ
-    constructor(width_block, height_block) {
-        super(width_block, height_block, true);
+    constructor(width_block, height_block, mode) {
+        super(width_block, height_block, false);
         this.clashenable = false;
+        // mode: 色の変化を制御する変数
+        // "red", "green", "blue"ならば対応する色を加算
+        // "inv"ならば背景と物体の色を反転
+        this.mode = mode
         this.changed = false;  // 色変更が完了すると立つフラグ
     }
 
     // 描画メソッド
     push() {
-        fill(this.red, this.green, this.blue, 50);
+        fill(255);
         noStroke();
+        rect(this.x, this.y, this.width, this.height);
+        fill(this.red, this.green, this.blue, 50);
         rect(this.x, this.y, this.width, this.height);
     }
 
@@ -23,15 +29,72 @@ class ColorChanger extends ObjectClass {
         touch += (chr.getX() <= this.x + this.width) ? 1 : 0;
         touch += (chr.getY() >= this.y - chr.getHeight()) ? 1 : 0;
         touch += (chr.getY() <= this.y + this.height) ? 1 : 0;
-        // 衝突した際の処理
-        //this.changed = (touch == 4) ? true : false;
+
+        // 衝突時の処理
         if (touch == 4 && !(this.changed)) {
-            if (bg.getRed() == 0) {
-                colorChange(chr, obj, bg, 0, 0, 0);
-                systemCChange(obj_retry, 0, 0, 0);
-            } else {
-                colorChange(chr, obj, bg, 255, 255, 255);
-                systemCChange(obj_retry, 255, 255, 255);
+            // 背景および物体が白色かどうか判定するための変数の定義
+            let bgcolor = bg.getRed() + bg.getGreen() + bg.getBlue();
+            let chrcolor = chr.getRed() + chr.getGreen() + chr.getBlue();
+
+            // modeが"inv"であるとき
+            if (this.mode == "inv") {
+                // 変更前の背景色の保持
+                let bgr = bg.getRed();
+                let bgg = bg.getGreen();
+                let bgb = bg.getBlue();
+                // 背景色の変更
+                bg.setRGB(chr.getRed(), chr.getGreen(), chr.getBlue());
+                // 物体色の変更
+                for (let i = 0; i < obj.length; i++) {
+                    if (obj[i].getCchange()) { obj[i].setRGB(bgr, bgg, bgb); }
+                }
+                // 自機の色の変更
+                chr.setRGB(bgr, bgg, bgb);
+
+            // 背景が白でないかつ物体が白であるとき
+            } else if (bgcolor != 765 && chrcolor == 765) {
+                let newr = bg.getRed();
+                let newg = bg.getGreen();
+                let newb = bg.getBlue();
+                // modeで指定した色を変更
+                switch (this.mode) {
+                    case "red"  : { newr = (bg.getRed() == 0) ? 255 : 0; break; }
+                    case "green": { newg = (bg.getGreen() == 0) ? 255 : 0; break; }
+                    case "blue" : { newb = (bg.getBlue() == 0) ? 255 : 0; break; }
+                }
+                bg.setRGB(newr, newg, newb);
+
+            // 背景が白かつ物体が白でないとき
+            } else if (bgcolor == 765 && chrcolor != 765) {
+                // 自機以外の物体の色変更
+                for (let i = 0; i < obj.length; i++) {
+                    // この辺りの処理は不必要である可能性有
+                    let newr = obj[i].getRed();
+                    let newg = obj[i].getGreen();
+                    let newb = obj[i].getBlue();
+                    switch (this.mode) {
+                        case "red"  : { newr = (obj[i].getRed() == 0) ? 255 : 0; break; }
+                        case "green": { newg = (obj[i].getGreen() == 0) ? 255 : 0; break; }
+                        case "blue" : { newb = (obj[i].getBlue() == 0) ? 255 : 0; break; }
+                    }
+                    if (obj[i].getCchange()) { obj[i].setRGB(newr, newg, newb); }
+                }
+                // 自機の色変更
+                let newr = chr.getRed();
+                let newg = chr.getGreen();
+                let newb = chr.getBlue();
+                switch (this.mode) {
+                    case "red"  : { newr = (chr.getRed() == 0) ? 255 : 0; break; }
+                    case "green": { newg = (chr.getGreen() == 0) ? 255 : 0; break; }
+                    case "blue" : { newb = (chr.getBlue() == 0) ? 255 : 0; break; }
+                }
+                chr.setRGB(newr, newg, newb);
+            }
+            // 変数の値の更新
+            bgcolor = bg.getRed() + bg.getGreen() + bg.getBlue();
+            chrcolor = chr.getRed() + chr.getGreen() + chr.getBlue();
+            if (bgcolor == 765 && chrcolor == 765) {
+                bg.setRGB(0, 0, 0);
             }
             this.changed = true;
         } else if (touch != 4) {

--- a/src/objects/object.js
+++ b/src/objects/object.js
@@ -52,6 +52,9 @@ class ObjectClass {
 
     getClashenable() { return this.clashenable; }
 
+    getRed() { return this.red; }
+    getGreen() { return this.green; }
+    getBlue() { return this.blue; }
     setRGB(red, green, blue) {
         this.red = red;
         this.green = green;

--- a/src/objects/transrect.js
+++ b/src/objects/transrect.js
@@ -22,6 +22,10 @@ class TransRectClass extends ObjectClass {
     // drawメソッドのclash関数の前で呼び出すこと
     setClash(bg) {
         // 白黒のみを考慮
-        this.clashenable = (bg.getRed() == this.red) ? false : true;
+        if (bg.getRed() == this.red && bg.getGreen() == this.green && bg.getBlue() == this.blue) {
+            this.clashenable = false;
+        } else {
+            this.clashenable = true;
+        }
     }
 }

--- a/src/stage/world0.js
+++ b/src/stage/world0.js
@@ -14,7 +14,7 @@ function world0() {
                     new RectClass(10, 1),
                     new RectClass(1, 10),
                     new TransRectClass(1, 5),
-                    new ColorChanger(1, 3),
+                    new ColorChanger(1, 3, "inv"),
                     new ClearLine(1, 3),
                     new GravityButton("floor"),
                     new GravityButton("ceiling"),
@@ -30,7 +30,7 @@ function world0() {
                 obj[2].init(10, 16, 255, 255, 255);
                 obj[3].init(13, 13, 0, 0, 0);  // 長方形を背景と同色で設置した場合のテスト
                 obj[4].init(25, 13, 255, 255, 255);
-                obj[5].init(19, 13, 255, 255, 255);
+                obj[5].init(19, 13, 0, 0, 0);
                 obj[6].init(37, 15, 255, 255, 255);
                 obj[7].init(5, 17, 255, 255, 255);
                 obj[8].init(7, 3, 255, 255, 255);
@@ -73,12 +73,14 @@ function world0() {
                     new RectClass(1, 2),
                     new TransRectClass(1, 8),
                     new TransRectClass(18, 1),
-                    new ColorChanger(1, 18),
-                    new ColorChanger(1, 18),
-                    new ColorChanger(1, 18),
+                    new ColorChanger(1, 16, "red"),
+                    new ColorChanger(1, 16, "green"),
+                    new ColorChanger(1, 16, "blue"),
                     new ClearLine(1, 3),
                     new OneWayWall(1, 3, "right"),
                     new OneWayWall(1, 3, "left"),
+                    new ColorChanger(1, 2, "inv")
+
                 ];
 
                 // 初期化
@@ -86,17 +88,18 @@ function world0() {
                 chr.init(0, 17, 0, 0, 0);
                 obj[0].init(0, 18, 0, 0, 0);
                 obj[1].init(5, 15, 0, 0, 0);
-                obj[2].init(9, 13, 0, 0, 0);
+                obj[2].init(9, 13, 255, 0, 0);
                 obj[3].init(12, 13, 255, 255, 255);
                 obj[4].init(15, 10, 0, 0, 0);
                 obj[5].init(20, 10, 0, 0, 0);
                 obj[6].init(20, 10, 0, 0, 0);
-                obj[7].init(8, 0, 0, 0, 0);
-                obj[8].init(13, 0, 0, 0, 0);
-                obj[9].init(18, 0, 0, 0, 0);
+                obj[7].init(8, 0, 255, 0, 0);
+                obj[8].init(13, 0, 0, 255, 0);
+                obj[9].init(18, 0, 0, 0, 255);
                 obj[10].init(37, 7, 0, 0, 0);
                 obj[11].init(27, 15, 0, 0, 0);
                 obj[12].init(32, 15, 0, 0, 0);
+                obj[13].init(11, 16, 0, 0, 0);
 
                 state = "draw";
 
@@ -111,6 +114,7 @@ function world0() {
                 obj[7].checkClash(chr);
                 obj[8].checkClash(chr);
                 obj[9].checkClash(chr);
+                obj[13].checkClash(chr);
                 clash(chr, obj);
                 chr.checkOffScreen();
                 chr.move();


### PR DESCRIPTION
以下の機能を追加及び修正した。
・colorchangerクラスを用いてRGBによる表色を可能とした
　・元々の黒色に色を足し引きする仕様
　・colorchangerクラスのコンストラクタの第3引数としてmodeを追加
　　・加減算する色を指定するための引数
　　・"inv"を指定することで単純な背景と物体の色の反転が可能
・transrectクラスの機能修正
　・RGBの処理に対応可能

ただし、物体の枠の色(stroke)を背景と同じ色にする処理が未実装であり、各オブジェクトのファイルにて適切な修正が求められることに注意したい。