### PR TITLE
オブジェクトのstrokeの色を修正

### DIFF
--- a/src/objects/character.js
+++ b/src/objects/character.js
@@ -64,8 +64,8 @@ class CharaClass {
         // 本体色と縁の色の設定
         // 縁の色は現状白黒のみに対応(要修正)
         fill(this.red, this.green, this.blue);
-        if (this.red + this.green + this.blue >= 255) {
-            stroke(0);
+        if (this.red + this.green + this.blue >= 765) {
+            stroke(bg.getRed(), bg.getGreen(), bg.getBlue());
         } else {
             stroke(255);
         }

--- a/src/objects/gravitybutton.js
+++ b/src/objects/gravitybutton.js
@@ -18,10 +18,10 @@ class GravityButton extends ObjectClass {
     // 描画メソッド
     push() {
         fill(this.red, this.green, this.blue);
-        if (this.red + this.green + this.blue >= 255) {
-            stroke(0);
+        if (this.red + this.green + this.blue >= 765) {
+            stroke(bg.getRed(), bg.getGreen(), bg.getBlue());
         } else {
-            stroke(255);
+            stroke(bg.getRed(), bg.getGreen(), bg.getBlue());
         }
         rect(this.x, this.y, this.width, this.height);
 

--- a/src/objects/onewaywall.js
+++ b/src/objects/onewaywall.js
@@ -10,8 +10,8 @@ class OneWayWall extends ObjectClass {
     // 描画メソッド
     push() {
         fill(this.red, this.green, this.blue);
-        if (this.red + this.green + this.blue >= 255) {
-            stroke(0);
+        if (this.red + this.green + this.blue >= 765) {
+            stroke(bg.getRed(), bg.getGreen(), bg.getBlue());
         } else {
             stroke(255);
         }

--- a/src/objects/rect.js
+++ b/src/objects/rect.js
@@ -8,8 +8,8 @@ class RectClass extends ObjectClass {
     // 描画メソッド
     push() {
         fill(this.red, this.green, this.blue);
-        if (this.red + this.green + this.blue >= 255) {
-            stroke(0);
+        if (this.red + this.green + this.blue >= 765) {
+            stroke(bg.getRed(), bg.getGreen(), bg.getBlue());
         } else {
             stroke(255);
         }

--- a/src/objects/transrect.js
+++ b/src/objects/transrect.js
@@ -9,17 +9,12 @@ class TransRectClass extends ObjectClass {
     // 描画メソッド
     push() {
         fill(this.red, this.green, this.blue);
-        if (this.red + this.green + this.blue >= 765) {
-            if (bg.getRed() + bg.getGreen() + bg.getBlue() >= 765) {
-                for (let i = 0; i < obj.length; i++) {
-                    if (obj[i].getRed() + obj[i].getGreen() + obj[i].getBlue() != 765 && obj[i].cchange) {
-                        stroke(obj[i].getRed(), obj[i].getGreen(), obj[i].getBlue());
-                        break;
-                    }
+        if (this.red + this.green + this.blue >= 765 && bg.getRed() + bg.getGreen() + bg.getBlue() >= 765) {
+            for (let i = 0; i < obj.length; i++) {
+                if (obj[i].getRed() + obj[i].getGreen() + obj[i].getBlue() != 765 && obj[i].cchange) {
+                    stroke(obj[i].getRed(), obj[i].getGreen(), obj[i].getBlue());
+                    break;
                 }
-            }
-            else {
-                stroke(bg.getRed(), bg.getGreen(), bg.getBlue());
             }
         } else if(this.getRed() == bg.getRed() && this.getGreen() == bg.getGreen() && this.getBlue() == bg.getBlue()) {
             stroke(255);

--- a/src/objects/transrect.js
+++ b/src/objects/transrect.js
@@ -9,8 +9,18 @@ class TransRectClass extends ObjectClass {
     // 描画メソッド
     push() {
         fill(this.red, this.green, this.blue);
-        if (this.red + this.green + this.blue >= 255) {
-            stroke(0);
+        if (this.red + this.green + this.blue >= 765) {
+            if (bg.getRed() + bg.getGreen() + bg.getBlue() >= 765) {
+                for (let i = 0; i < obj.length; i++) {
+                    if (obj[i].getRed() + obj[i].getGreen() + obj[i].getBlue() != 765 && obj[i].cchange) {
+                        stroke(obj[i].getRed(), obj[i].getGreen(), obj[i].getBlue());
+                        break;
+                    }
+                }
+            }
+            else {
+                stroke(bg.getRed(), bg.getGreen(), bg.getBlue());
+            }
         } else {
             stroke(255);
         }

--- a/src/objects/transrect.js
+++ b/src/objects/transrect.js
@@ -21,9 +21,12 @@ class TransRectClass extends ObjectClass {
             else {
                 stroke(bg.getRed(), bg.getGreen(), bg.getBlue());
             }
-        } else {
+        } else if(this.getRed() == bg.getRed() && this.getGreen() == bg.getGreen() && this.getBlue() == bg.getBlue()) {
             stroke(255);
+        } else {
+            stroke(bg.getRed(), bg.getGreen(), bg.getBlue());
         }
+        
         rect(this.x, this.y, this.width, this.height);
         circle(this.x + this.width / 2, this.y + this.height / 2, 30);
     }

--- a/src/objects/unjumpablesign.js
+++ b/src/objects/unjumpablesign.js
@@ -9,8 +9,8 @@ class UnjumpableSign extends ObjectClass {
     // 描画メソッド
     push() {
         fill(this.red, this.green, this.blue);
-        if (this.red + this.green + this.blue >= 255) {
-            stroke(0);
+        if (this.red + this.green + this.blue >= 765) {
+            stroke(bg.getRed(), bg.getGreen(), bg.getBlue());
         } else {
             stroke(255);
         }

--- a/src/objects/warpportal.js
+++ b/src/objects/warpportal.js
@@ -20,8 +20,8 @@ class WarpPortal extends ObjectClass {
     // 描画メソッド
     push() {
         fill(this.red, this.green, this.blue);
-        if (this.red + this.green + this.blue >= 255) {
-            stroke(0);
+        if (this.red + this.green + this.blue >= 765) {
+            stroke(bg.getRed(), bg.getGreen(), bg.getBlue());
         } else {
             stroke(255);
         }

--- a/src/stage/world0.js
+++ b/src/stage/world0.js
@@ -58,7 +58,7 @@ function world0() {
                 clash(chr, obj);  // 衝突判定処理
                 chr.checkOffScreen();  // 落下判定と水平方向への衝突処理
 
-                chr.setJumpenable(false);  // ジャンプ禁止の設定
+                //chr.setJumpenable(false);  // ジャンプ禁止の設定
               
                 chr.move();  // 自機の左右移動
                 chr.push();  // 自機の描画


### PR DESCRIPTION
strokeのあるオブジェクトのstrokeの色をbgの色に合わせた。
透過ブロックだけはbgに合わせると全く見えなくなるときがあるので、白以外の透過ブロックはstrokeを白に統一し、白の透過ブロックはstrokeをそのときの世界の色に合わせた。
また、ジャンプ禁止が鬱陶しいので、いったん処理をコメントアウトにした。